### PR TITLE
Fix X86 problem and rename incorrect mapping for ABI

### DIFF
--- a/.idea/codeStyles/codeStyleConfig.xml
+++ b/.idea/codeStyles/codeStyleConfig.xml
@@ -1,5 +1,6 @@
 <component name="ProjectCodeStyleConfiguration">
   <state>
     <option name="USE_PER_PROJECT_SETTINGS" value="true" />
+    <option name="PREFERRED_PROJECT_CODE_STYLE" value="Default" />
   </state>
 </component>

--- a/.idea/modules.xml
+++ b/.idea/modules.xml
@@ -4,6 +4,7 @@
     <modules>
       <module fileurl="file://$PROJECT_DIR$/demo-hello-world/demo-hello-world.iml" filepath="$PROJECT_DIR$/demo-hello-world/demo-hello-world.iml" />
       <module fileurl="file://$PROJECT_DIR$/demo-payment-usecase/demo-payment-usecase.iml" filepath="$PROJECT_DIR$/demo-payment-usecase/demo-payment-usecase.iml" />
+      <module fileurl="file://$PROJECT_DIR$/plasma-android-sdk.iml" filepath="$PROJECT_DIR$/plasma-android-sdk.iml" />
       <module fileurl="file://$PROJECT_DIR$/.idea/plasma-android-sdk.iml" filepath="$PROJECT_DIR$/.idea/plasma-android-sdk.iml" />
       <module fileurl="file://$PROJECT_DIR$/plasma_android_sdk/plasma_android_sdk.iml" filepath="$PROJECT_DIR$/plasma_android_sdk/plasma_android_sdk.iml" />
     </modules>

--- a/README.md
+++ b/README.md
@@ -65,6 +65,17 @@ Your build command should look like
 $ sh tools/build.sh
 ```
 
+But before that since make sure you have folder named `arm64-v8a`, `armeabi-v7a`, `x86`, under `plasma-android-sdk/plasma_android_sdk/jni-libs/`.
+If not create folder and run the script.
+
+If you don't have those folders, you will see following error message and just fix typo etc...
+
+```
+cp: ../plasma_android_sdk/jni-libs/arm64-v8a/libplasma_android_sdk.so: No such file or directory
+cp: ../plasma_android_sdk/jni-libs/armeabi-v7a/libplasma_android_sdk.so: No such file or directory
+cp: ../plasma_android_sdk/jni-libs/x86/libplasma_android_sdk.so: No such file or directory
+```
+
 This will do all the following work for you.
 1. copy config file to global config, so that `cargo build` will look at that config.
 2. build rust source code to each OS targets.

--- a/plasma_android_sdk/build.gradle
+++ b/plasma_android_sdk/build.gradle
@@ -13,6 +13,9 @@ android {
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
 
+        ndk {
+            abiFilters "arm64-v8a", "armeabi-v7a", "x86"
+        }
     }
 
     buildTypes {

--- a/rust/tools/build.sh
+++ b/rust/tools/build.sh
@@ -11,4 +11,4 @@ cargo build --target i686-linux-android --release
 
 cp ./target/aarch64-linux-android/release/${file_name} ${jni_path}/arm64/${file_name}
 cp ./target/armv7-linux-androideabi/release/${file_name} ${jni_path}/armeabi/${file_name}
-cp ./target/i686-linux-android/release/${file_name} ${jni_path}/x86/l${file_name}
+cp ./target/i686-linux-android/release/${file_name} ${jni_path}/x86/${file_name}

--- a/rust/tools/build.sh
+++ b/rust/tools/build.sh
@@ -9,6 +9,9 @@ cargo build --target aarch64-linux-android --release
 cargo build --target armv7-linux-androideabi --release
 cargo build --target i686-linux-android --release
 
-cp ./target/aarch64-linux-android/release/${file_name} ${jni_path}/arm64/${file_name}
-cp ./target/armv7-linux-androideabi/release/${file_name} ${jni_path}/armeabi/${file_name}
+# directory name should be matched with ABI
+# see https://forge.rust-lang.org/platform-support.html for rust targets
+# see https://developer.android.com/ndk/guides/abis for abi name
+cp ./target/aarch64-linux-android/release/${file_name} ${jni_path}/arm64-v8a/${file_name}
+cp ./target/armv7-linux-androideabi/release/${file_name} ${jni_path}/armeabi-v7a/${file_name}
 cp ./target/i686-linux-android/release/${file_name} ${jni_path}/x86/${file_name}


### PR DESCRIPTION
What
- [x] Fix X86 .so file typo
- [x] Rename arm64 to arm64-v8a
- [x] Rename armeabi armeabi-v7a
- [x] Update README.md to create folder under `jnilibs`

close #8 